### PR TITLE
Allow other python default location

### DIFF
--- a/runHALC.py
+++ b/runHALC.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import argparse


### PR DESCRIPTION
Modification to make `runHALC.py` works on systems where default python is not installed in `/usr/bin/python`